### PR TITLE
Fixing missing hhsuite_tsv_file.ff{data,index}

### DIFF
--- a/bin/modules/processes.py
+++ b/bin/modules/processes.py
@@ -110,7 +110,8 @@ def run_hmmsuite(db_dir, out_dir):
     print("Running hmmsuite")
     hmmsuite_db_dir = os.path.join(db_dir, "phrogs_hhsuite_db/")
     amino_acid_fasta = "phanotate_aas.fasta"
-    target_db_dir =  os.path.join(out_dir, "hhsuite_target_dir/") 
+    target_db_dir =  os.path.join(out_dir, "hhsuite_target_dir/")
+    tsv_prefix = os.path.join(target_db_dir, 'hhsuite_tsv_file.ff') 
 
     # make dir for target db
     if os.path.isdir(target_db_dir) == False:
@@ -118,9 +119,16 @@ def run_hmmsuite(db_dir, out_dir):
 
 
     # indexes the file 
-    #can't pass curly brackets to subprocess so need to run using os
-    cmd = 'ffindex_from_fasta -s ' + os.path.join(target_db_dir, 'hhsuite_tsv_file.ff{data,index}') + " " + os.path.join(out_dir, amino_acid_fasta)
-    os.system(cmd)
+    sp.run(
+        [
+            'ffindex_from_fasta',
+            '-s',
+            ''.join((tsv_prefix, 'data')),
+            ''.join((tsv_prefix, 'index')),
+            os.path.join(out_dir, amino_acid_fasta),
+        ],
+        check=True
+    )
 
 
     # runs


### PR DESCRIPTION
Bc of the brackets chars some shells (like mine) could not be able to do str
expansion so i change it to be two string "hhsuite_tsv_file.ffdata" and "hhsuite_tsv_file.ffindex" .
I also change the this call from a os.run call for a subprocess call with the flag check=True,
this way the return code of the the index subprocess will be captured and bugs on this step could be
detected early.